### PR TITLE
Update repository clone command and publisher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Before you begin, ensure you have the following installed:
 
 1. Clone this repository:
 	```shell
-	git clone https://github.com/onconova/onconova-fhir-ig.git
+	git clone https://github.com/onconova/fhir.git onconova-fhir-ig
 	cd onconova-fhir-ig
 	```
 2. Install FHIR SUSHI and IG Publisher:
 	```shell
 	npm install -g fsh-sushi
-	./fhir/ig/_updatePublisher.sh
+	source _updatePublisher.sh -y
 	```
 
 ## Build IG


### PR DESCRIPTION
This pull request updates the setup instructions in the `README.md` to clarify the repository cloning process and improve the installation steps for FHIR SUSHI and the IG Publisher.

Documentation improvements:

* Changed the `git clone` command to clone the repository into the `onconova-fhir-ig` directory for consistency with subsequent instructions.
* Updated the IG Publisher installation step to use `source _updatePublisher.sh -y` instead of referencing a nested script path, simplifying the setup process.