### PR TITLE
Correct gender invariant expression requirement

### DIFF
--- a/input/fsh/SD_PatientCase.fsh
+++ b/input/fsh/SD_PatientCase.fsh
@@ -152,7 +152,7 @@ Severity: #error
 
 Invariant: o-pat-req-3
 Description: "The gender element is required and must be provided"
-Expression: "gender.exists() and gender.coding.exists()"
+Expression: "gender.exists()"
 Severity: #error
 
 Invariant: o-pat-req-4


### PR DESCRIPTION
This pull request makes a small change to the invariant definition in the `SD_PatientCase.fsh` file, simplifying the required check for the `gender` element.

* The invariant `o-pat-req-3` now only checks that `gender.exists()`, removing the requirement for `gender.coding.exists()`.