### PR TITLE
Change value type from decimal to duration

### DIFF
--- a/input/fsh/SD_PatientCase.fsh
+++ b/input/fsh/SD_PatientCase.fsh
@@ -83,7 +83,7 @@ Extension: OverallSurvival
 Id: onconova-ext-overall-survival
 Title: "Overall Survival"
 Description: "The duration of time from either the date of diagnosis or the start of treatment for a disease, such as cancer, that patients diagnosed with the disease are still alive. In a clinical trial, measuring the overall survival is one way to see how well a new treatment works."
-* value[x] only duration 
+* value[x] only Duration 
 
 // Extension: Age
 // Captures the approximate age of the patient


### PR DESCRIPTION
This pull request updates the definition of the `OverallSurvival` extension in the `SD_PatientCase.fsh` file to better represent the intended data type for overall survival measurements.

* Data Model Update:
  * Changed the `value[x]` type for the `onconova-ext-overall-survival` extension from `decimal` to `duration`, ensuring that overall survival is captured as a time duration rather than a raw number.