### PR TITLE
Remove recurrence extensions from secondary cancer condition profile

### DIFF
--- a/input/fsh/SD_Condition.fsh
+++ b/input/fsh/SD_Condition.fsh
@@ -93,10 +93,6 @@ It constrains the mCODE [SecondaryCancerCCondition profile](http://hl7.org/fhir/
 * extension[histologyMorphologyBehavior] 1..1
 * extension[histologyMorphologyBehavior].valueCodeableConcept from ICDO3MorphologyBehavior (required)
 
-// Add extension to indicate whether the condition is a recurrence of a previous condition
-* extension contains RecurrenceOf named recurrenceOf 0..1 
-* clinicalStatus.extension contains RecurrenceType named recurrenceType 0..1
-
 // Constratin the cancer topography to use ICD-O-3 codes and be required 
 * bodySite 1..*
 * bodySite from ICDO3Topography (required)
@@ -112,9 +108,7 @@ It constrains the mCODE [SecondaryCancerCCondition profile](http://hl7.org/fhir/
 * insert NotUsed(severity)
 
 // Constraints 
-* obeys o-con-1 and 
-    o-con-2 and
-    o-con-req-1 and
+* obeys o-con-req-1 and
     o-con-req-2 and
     o-con-req-3 and 
     o-con-req-4


### PR DESCRIPTION
This pull request makes updates to the `SD_Condition.fsh` file, primarily focused on removing extensions related to recurrence and adjusting constraint rules for the mCODE SecondaryCancerCondition profile. These changes streamline the profile by eliminating recurrence-specific extensions and simplifying the constraint logic.

Profile structure updates:

* Removed the `RecurrenceOf` and `RecurrenceType` extensions, which previously indicated whether the condition was a recurrence of a previous condition and its type.

Constraint logic changes:

* Updated the list of enforced constraints by removing `o-con-1` and `o-con-2`, leaving only the required constraints (`o-con-req-1`, `o-con-req-2`, `o-con-req-3`, `o-con-req-4`).