### PR TITLE
Add exclusions to Surgical Procedures Value Set

### DIFF
--- a/input/fsh/VS_SurgicalProcedures.fsh
+++ b/input/fsh/VS_SurgicalProcedures.fsh
@@ -4,3 +4,7 @@ Title: "Surgical Procedures Value Set"
 Description: "Set of surgical procedures relevant to cancer treatment in Onconova."
 
 * include codes from system $NCIT where concept descendent-of #C15329
+* exclude $NCIT#C49165
+* exclude $NCIT#C49163
+* exclude $NCIT#C161601
+* exclude $NCIT#C64982


### PR DESCRIPTION
This pull request updates the `VS_SurgicalProcedures.fsh` value set definition to refine the set of surgical procedures relevant to cancer treatment. The main change is the exclusion of several specific NCIT codes from the value set.

Refinement of surgical procedures value set:

* [`input/fsh/VS_SurgicalProcedures.fsh`](diffhunk://#diff-5acce6e44fd73fa8e8f8cc995ff33b99644f604e1eee7d923640404490a03d9bR7-R10): Excluded the following NCIT codes from the value set: `C49165`, `C49163`, `C161601`, and `C64982`. This ensures these specific procedures are not included when selecting codes that are descendants of `C15329`.