### PR TITLE
Fix expression syntax for ctcae-grade invariant

### DIFF
--- a/input/fsh/SD_AdverseEvent.fsh
+++ b/input/fsh/SD_AdverseEvent.fsh
@@ -114,7 +114,7 @@ Description: "The grade of the adverse event as defined by the Common Terminolog
 
 Invariant: ctcae-grade
 Description: "The CTCAE grade must be between 1 and 5, inclusive."
-Expression: "valueInteger() >= 1 and valueInteger() <= 5"
+Expression: "valueInteger >= 1 and valueInteger <= 5"
 Severity: #error
 
 Extension: AdverseEventMitigation


### PR DESCRIPTION
This pull request makes a minor update to the expression syntax in the `ctcae-grade` invariant, ensuring compatibility with FHIRPath standards.

### Fixed

- Updated the `Expression` in the `ctcae-grade` invariant within `SD_AdverseEvent.fsh` to remove parentheses, now using `valueInteger >= 1 and valueInteger <= 5` for correct FHIRPath syntax.