### PR TITLE
Update invariant expressions to use Onconova-specific URLs for vital status and cause of death

### DIFF
--- a/input/fsh/SD_PatientCase.fsh
+++ b/input/fsh/SD_PatientCase.fsh
@@ -192,15 +192,15 @@ Severity: #error
 
 Invariant: o-pat-req-5
 Description: "The vital status extension is required and must be provided."
-Expression: "deceased.extension('http://hl7.org/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.exists()"
+Expression: "deceased.extension('http://onconova.github.io/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.exists()"
 Severity: #error
 
 Invariant: o-pat-req-6
 Description: "If the patient is deceased, the date of death and cause of death must be provided."
-Expression: "deceasedDateTime.extension('http://hl7.org/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.coding.code = '419099009' implies (deceasedDateTime.hasValue() and deceasedDateTime.extension('http://hl7.org/fhir/StructureDefinition/onconova-ext-cancer-patient-cause-of-death').valueCodeableConcept.exists())"
+Expression: "deceasedDateTime.extension('http://onconova.github.io/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.coding.code = '419099009' implies (deceasedDateTime.hasValue() and deceasedDateTime.extension('http://onconova.github.io/fhir/StructureDefinition/onconova-ext-cancer-patient-cause-of-death').valueCodeableConcept.exists())"
 Severity: #error
 
 Invariant: o-pat-req-7
 Description: "If the patient vital status is unknown, the end of records must be provided."
-Expression: "deceasedDateTime.extension('http://hl7.org/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.coding.code = '261665006' implies extension('http://hl7.org/fhir/StructureDefinition/onconova-ext-cancer-patient-end-of-records').valueDate.hasValue()"
+Expression: "deceasedDateTime.extension('http://onconova.github.io/fhir/StructureDefinition/onconova-ext-cancer-patient-vital-status').valueCodeableConcept.coding.code = '261665006' implies extension('http://onconova.github.io/fhir/StructureDefinition/onconova-ext-cancer-patient-end-of-records').valueDate.hasValue()"
 Severity: #error


### PR DESCRIPTION
This pull request updates the URLs used in several FHIR invariants to point to the correct Onconova GitHub-hosted StructureDefinition endpoints, ensuring consistency and accuracy in extension references.

### Fixed

* Updated all relevant invariant `Expression` fields in `SD_PatientCase.fsh` to use `http://onconova.github.io/fhir/StructureDefinition/` instead of the incorrect `http://hl7.org/fhir/StructureDefinition/` prefix for Onconova-specific extensions.